### PR TITLE
Allow use of serial ports other than Serial0 + Add 1024 bit mode.

### DIFF
--- a/RcSatelliteReceiver.cpp
+++ b/RcSatelliteReceiver.cpp
@@ -43,6 +43,21 @@ void RcSatelliteReceiver::setDebugSerialPort(Stream *streamObject)
 {
 	_DebugSerialPort = streamObject;
 }
+
+void RcSatelliteReceiver::setMode2048(void)
+{
+	_mask_chanid = MASK_2048_CHANID;
+	_mask_sxpos = MASK_2048_SXPOS;
+	_rot_chanid = ROT_2048_CHANID;
+}
+
+void RcSatelliteReceiver::setMode1024(void)
+{
+	_mask_chanid = MASK_1024_CHANID;
+	_mask_sxpos = MASK_1024_SXPOS;
+	_rot_chanid = ROT_1024_CHANID;
+}
+
 void RcSatelliteReceiver::readChannelValues(void)
 {
 	int startingByteCount = _RxSerialPort->available();
@@ -127,18 +142,14 @@ void RcSatelliteReceiver::readChannelValues(void)
 
 int RcSatelliteReceiver::getChannelNumber(int servoData)
 {
-	uint8_t highByte = highByte(servoData);
-	const int CHANNEL_NUMBER_MASK = B01111000;
-	int channelNumber = (highByte & CHANNEL_NUMBER_MASK) >> 3; // convert the 4 bits to an int value for the channel
+	int channelNumber = (servoData & _mask_chanid) >> _rot_chanid; // convert the bits to an int value for the channel
 	return channelNumber;
 }
 
 int RcSatelliteReceiver::getChannelValue(int servoData)
 {
-	const int HIGHBYTE_CHANNEL_VALUE_MASK = B00000111;
-	uint8_t highByte = highByte(servoData);
-	uint8_t lowByte = lowByte(servoData);
-	int channelValue = (((int)highByte & HIGHBYTE_CHANNEL_VALUE_MASK) << 8) | (int)lowByte; // 342 is the lowest value so we adjust to make it 0
+
+	int channelValue = (servoData & _mask_sxpos); 
 	return channelValue;
 }
 

--- a/RcSatelliteReceiver.cpp
+++ b/RcSatelliteReceiver.cpp
@@ -49,6 +49,8 @@ void RcSatelliteReceiver::setMode2048(void)
 	_mask_chanid = MASK_2048_CHANID;
 	_mask_sxpos = MASK_2048_SXPOS;
 	_rot_chanid = ROT_2048_CHANID;
+	MaxChannelValue = CV_2048_MAX;
+	MinChannelValue = CV_2048_MIN;
 }
 
 void RcSatelliteReceiver::setMode1024(void)
@@ -56,6 +58,8 @@ void RcSatelliteReceiver::setMode1024(void)
 	_mask_chanid = MASK_1024_CHANID;
 	_mask_sxpos = MASK_1024_SXPOS;
 	_rot_chanid = ROT_1024_CHANID;
+	MaxChannelValue = CV_2048_MAX / 2;
+	MinChannelValue = CV_2048_MIN / 2;
 }
 
 void RcSatelliteReceiver::readChannelValues(void)

--- a/RcSatelliteReceiver.h
+++ b/RcSatelliteReceiver.h
@@ -12,6 +12,8 @@
 class RcSatelliteReceiver {
 public:
 	RcSatelliteReceiver(void);
+	RcSatelliteReceiver(Stream *rxSerialPort);
+	RcSatelliteReceiver(Stream *rxSerialPort, Stream *debugSerialPort);
 	void readChannelValues(void);
 	int getChannel(int chanelNumber);
 	int getThr();
@@ -24,6 +26,8 @@ public:
 	const int MaxChannelValue = 1706;
 	const int MessageLength = 16;
 	unsigned long FailsafeDelayMilliseconds = 250; // milliseconds since the last receive to wait before enabling Fail-Safe values
+	void setRxSerialPort(Stream *rxSerialPort);
+	void setDebugSerialPort(Stream *debugSerialPort);
 
 private:
 	int getChannelNumber(int servoData);
@@ -32,6 +36,8 @@ private:
 	int _channelValues[12];
 	int _channelFailsafeValues[12];
 	unsigned long _lastReceiveMillis = 0;
+	Stream *_RxSerialPort;
+	Stream *_DebugSerialPort;
 };
 
 #endif // RCSATELLITERECEIVER_H_

--- a/RcSatelliteReceiver.h
+++ b/RcSatelliteReceiver.h
@@ -25,9 +25,17 @@ public:
 	const int MinChannelValue = 342;
 	const int MaxChannelValue = 1706;
 	const int MessageLength = 16;
+	const int MASK_1024_CHANID = 0xFC00;
+	const int ROT_1024_CHANID = 10;
+	const int MASK_1024_SXPOS = 0x03FF;
+	const int MASK_2048_CHANID = 0x7800;
+	const int ROT_2048_CHANID = 11;
+	const int MASK_2048_SXPOS = 0x07FF;
 	unsigned long FailsafeDelayMilliseconds = 250; // milliseconds since the last receive to wait before enabling Fail-Safe values
 	void setRxSerialPort(Stream *rxSerialPort);
 	void setDebugSerialPort(Stream *debugSerialPort);
+	void setMode1024();
+	void setMode2048();
 
 private:
 	int getChannelNumber(int servoData);
@@ -38,6 +46,9 @@ private:
 	unsigned long _lastReceiveMillis = 0;
 	Stream *_RxSerialPort;
 	Stream *_DebugSerialPort;
+	int _mask_chanid = MASK_2048_CHANID;
+	int _rot_chanid = ROT_2048_CHANID;
+	int _mask_sxpos = MASK_2048_SXPOS;
 };
 
 #endif // RCSATELLITERECEIVER_H_

--- a/RcSatelliteReceiver.h
+++ b/RcSatelliteReceiver.h
@@ -22,8 +22,8 @@ public:
 	int getRud();
 	unsigned long getMillisSinceLastReceive();
 	void setChannelFailsafeValue(int channel, int value);
-	const int MinChannelValue = 342;
-	const int MaxChannelValue = 1706;
+	int CV_2048_MAX = 1706;
+	int CV_2048_MIN = 342;
 	const int MessageLength = 16;
 	const int MASK_1024_CHANID = 0xFC00;
 	const int ROT_1024_CHANID = 10;
@@ -31,6 +31,8 @@ public:
 	const int MASK_2048_CHANID = 0x7800;
 	const int ROT_2048_CHANID = 11;
 	const int MASK_2048_SXPOS = 0x07FF;
+	int MinChannelValue = CV_2048_MIN;
+	int MaxChannelValue = CV_2048_MAX;
 	unsigned long FailsafeDelayMilliseconds = 250; // milliseconds since the last receive to wait before enabling Fail-Safe values
 	void setRxSerialPort(Stream *rxSerialPort);
 	void setDebugSerialPort(Stream *debugSerialPort);


### PR DESCRIPTION
Defaults should be the same, 2048 bit + using 0th Serial port, but this allows you to pass in different serial ports for debug and the receiver (for example on an arduino mega.

```
#include <Arduino.h>
#include "RcSatelliteReceiver.h"

RcSatelliteReceiver Receiver;

void setup ()
{
    Serial.begin(115200);
    Serial1.begin(115200);
    Receiver.setRxSerialPort(&Serial1);
    Receiver.setDebugSerialPort(&Serial);
    Receiver.setMode1024();
}

void loop ()
{
    Receiver.readChannelValues();
    Serial.print("Channel values: ");
	for (int i = 1; i < 7; i++)
	{
		Serial.print(i);
		Serial.print(':');
		Serial.print(Receiver.getChannel(i));
		Serial.print('\t');
	}
	Serial.println();
    delay(10);
}
```

Is the test code i've used for developing it.  I've fully tested it in 1024 bit mode, not tested in 2048 bit because i don't have any new enough receivers, but it shouldn't be any different.